### PR TITLE
adding release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    tags:
+      - 'v?[0-9]+.[0-9]+.[0-9]+'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: changelog
+        uses: scottbrenner/generate-changelog-action@v1.3.3
+        id: changelog
+        env:
+          REPO: ${{ github.repository }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
+
+
+  build:
+    needs: create_release
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            os: linux
+            go_version: 1.17
+          - arch: arm64
+            os: linux
+            go_version: 1.17
+          - arch: arm64
+            os: darwin
+            go_version: 1.17
+          - arch: amd64
+            os: darwin
+            go_version: 1.17
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go ${{matrix.go_version}} for ${{ matrix.os }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go_version }}
+
+      - name: Build
+        run: make clean all GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: site-${{ matrix.os }}-${{ matrix.arch }}
+          path: bin/site
+
+      - name: Attach artifact to release
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const fs = require('fs');
+            const tag = context.ref.replace("refs/tags/", "");
+            // Get release for this tag
+            const release = await github.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag
+            });
+            // Upload the release asset
+            await github.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.data.id,
+              name: "site-${{ matrix.os }}-${{matrix.arch}}",
+              data: await fs.readFileSync("bin/site")
+            });

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ pkg := $(shell go list -m)
 
 all: build
 
-.PHONY: build dev
+.PHONY: build dev clean
+
+clean:
+	rm bin/site || :
 
 build:
 	go build -o bin/$(NAME) \


### PR DESCRIPTION
Create a `release.yml` action to take care of creating release notes and releases when a tag like `v1.2.3` is created. This will also build the site for mac+linux and attach the binaries to the release.